### PR TITLE
add yarn package manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,12 @@ RUN curl -sS https://getcomposer.org/installer | php && \
     # generate accesskey for app https://github.com/organizations/sealink/settings/applications/308702
     composer config -g github-oauth.github.com 8e52e76a7ff35c03076f0d2382ad205b5a06f42f
 
+# yarn package manager
+RUN apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg && \
+    echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 # Add Node sources and apt-get update
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
-    apt-get install -y build-essential nodejs
+    apt-get install -y build-essential nodejs yarn
 
 # Clean
 RUN apt-get clean && rm -r /var/lib/apt/lists/*


### PR DESCRIPTION
Add [yarn](https://yarnpkg.com/) for better node package installs. Creates a yarn.lock file based on package.json packages so the install is the same everywhere. 

Works as replacement in for npm - see https://yarnpkg.com/en/docs/migrating-from-npm

Updates to php 7.0.12 too. <img width="983" alt="screen shot 2016-11-14 at 10 14 50 am" src="https://cloud.githubusercontent.com/assets/89775/20249894/5757df86-aa53-11e6-9f8b-833eeb1a46df.png">
