### PR TITLE
Update to latest php 7.0.9 > 7.0.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # Add sources for latest nginx
 RUN apt-get clean && apt-get update && apt-get install -y wget
-RUN wget -q http://nginx.org/keys/nginx_signing.key -O- | sudo apt-key add -
+RUN wget -q http://nginx.org/keys/nginx_signing.key -O- | apt-key add -
 RUN echo deb http://nginx.org/packages/mainline/ubuntu/ trusty nginx >> /etc/apt/sources.list
 RUN echo deb-src http://nginx.org/packages/mainline/ubuntu/ trusty nginx >> /etc/apt/sources.list
 
@@ -43,7 +43,7 @@ RUN curl -sS https://getcomposer.org/installer | php && \
 
 # yarn package manager
 RUN apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg && \
-    echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+    echo "deb http://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 # Add Node sources and apt-get update
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
     apt-get install -y build-essential nodejs yarn

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04.4
+FROM ubuntu:16.04
 
 # Suppress Upstart errors/warning
 RUN dpkg-divert --local --rename --add /sbin/initctl


### PR DESCRIPTION
Don't expect this to be merged. But thought I'd highlight that the craft docker base is quite out of date. 

updates the following packages:
- nginx 1.13.0
- yarn 0.24.5
- node 6.10.3